### PR TITLE
Update docs and links

### DIFF
--- a/faq.md
+++ b/faq.md
@@ -5,11 +5,6 @@ permalink: /faq/
 
 # Frequently asked questions about Trove
 
-
-## I can't see any projects/ I didn't get a signup email
-
-<<***NOTE:*** Between 9/11/2020 and 9/22/2020 - Trove will be switching over to a new model supporting **direct payments for your photos**. If you already have the app installed, you may no longer see any projects in the app during this time. If you are signing up, your onboarding might be delayed until 9/19. We apologize for the incoveninence.>>
-
 ## What is Trove?
 
 Trove is a marketplace app that lets you earn money by sharing photos with AI projects. Trove works with AI developers to create projects looking for photos. You can view a project's details, share your photos and get paid if your photos are useful in a project.
@@ -55,7 +50,7 @@ If your photos are approved by the developer for use in their project, you will 
 
 ***Android users***: You can download Trove from the **[Google Play Store](https://aka.ms/troveandroid)**
 
-***iOS users***: You can visit Trove's **[mobile website](https://aka.ms/troveweb)**
+***iOS users***: You can download Trove from the **[Apple App Store](https://aka.ms/troveios)**
 
 If you are an AI developer and would like to learn more about adding your project in Trove, please **[sign up here](https://aka.ms/troveaddproject)**. 
 

--- a/index.md
+++ b/index.md
@@ -2,10 +2,7 @@
 
 <br/>
 
-[Trove Terms of Use](./Trove Terms of Use.pdf)
-<br/>
-
-[Trove Limited Preview Sweepstakes Rules](/Trove Limited Preview Sweepstakes Official Rules.pdf)
+[Trove Terms of Use](./Trove%20Terms%20of%20Use.pdf)
 <br/>
 
 [Trove Community Standards](/communitystandards/)
@@ -14,8 +11,8 @@
 [Trove FAQ](/faq/)
 <br/>
 
-[How to send photos](/sendphotos/)
+[Learn more about sharing photos in Trove](/photoaccess/)
 <br/>
 
-[Contact Us](https://aka.ms/trovefeedback) | [Privacy & Cookies](https://go.microsoft.com/fwlink/?LinkId=521839) | [Terms of Use](https://aka.ms/trovetermsofuse) | [Code of Conduct](https://aka.ms/trovecommunitystandards) | [Trademarks](https://go.microsoft.com/fwlink/?LinkId=506942) | © Microsoft Corporation 2020
+[Contact Us](https://aka.ms/trovefeedback) | [Privacy & Cookies](https://go.microsoft.com/fwlink/?LinkId=521839) | [Terms of Use](https://aka.ms/trovetermsofuse) | [Code of Conduct](https://aka.ms/trovecommunitystandards) | [Trademarks](https://go.microsoft.com/fwlink/?LinkId=506942) | © Microsoft Corporation 2021
 

--- a/photoaccess.md
+++ b/photoaccess.md
@@ -16,7 +16,7 @@ Trove can only access photos on your phone. Photos (or any info about them) do n
 
 When you click "Send photos" on any project, Trove asks you to select specific photos on your phone. 
 
-Certain projects do not accept photos with people. You may see a warning asking to review photos you select if they contain people. However, regardless of the presence of any warning, you are solely responsible for ensuring you don’t share photos that violate the requirements of the project, the [Trove Terms of Use](https://aka.ms/trovetermsofuse), or the [Trove Community Standards](../communitystandards/)
+Certain projects do not accept photos with people. You may see a warning asking to review photos you select if they contain people. However, regardless of the presence of any warning, you are solely responsible for ensuring you don’t share photos that violate the requirements of the project, the [Trove Terms of Use](../Trove%20Terms%20of%20Use.pdf), or the [Trove Community Standards](../communitystandards/)
 
 Only the photos you select are uploaded and shared with the ML developer. Trove does not share any photos or data beyond the photos you specifically select for a project.
 


### PR DESCRIPTION
Removed outdated and broken links as well as update links to latest docs.
Removed FAQ on sign-up email
Updated year of copyright
update iOS download link to aka.ms/troveios